### PR TITLE
better implementation for `isinf`

### DIFF
--- a/src/GarbageMath.jl
+++ b/src/GarbageMath.jl
@@ -64,7 +64,7 @@ Base.:(*)(x::Number, y::XKCDNumber) = y * x
 
 Base.abs(x::XKCDNumber{N}) where {N} = XKCDNumber{N}(abs(x.n))
 Base.isnan(x::XKCDNumber) = isnan(x.n)
-Base.isinf(x::XKCDNumber) = isinf(x.n)
+Base.isinf(x::XKCDNumber) = abs(x.n) >= 3
 Base.Float64(x::XKCDNumber{N}) where {N} = Float64(x.n)  
 
 Base.AbstractFloat(x::XKCDNumber{N}) where {N} = AbstractFloat(x.n)


### PR DESCRIPTION
Thanks for this package! I find it really useful for our physics lab, since all the data we get is garbage anyways, so thanks to GarbageMath, I know right away that our result will be garbage too. No more annoying Gaussian error propagation and guessing numerical uncertainties until the error bars for the plot look nice! I have always found dealing with large numbers to be quite frustrating though; I think for all practical application treating 3 as infinity should be reasonable enough.